### PR TITLE
Update scala-for-java-programmers.md

### DIFF
--- a/_overviews/tutorials/scala-for-java-programmers.md
+++ b/_overviews/tutorials/scala-for-java-programmers.md
@@ -588,9 +588,8 @@ abstract one. The predicates for equality and inequality do not appear
 here since they are by default present in all objects.
 
 The type `Any` which is used above is the type which is a
-super-type of all other types in Scala. It can be seen as a more
-general version of Java's `Object` type, since it is also a
-super-type of basic types like `Int`, `Float`, etc.
+super-type of all other types in Scala. It can be considered
+as an equivalent of `Object` in Java.
 
 To make objects of a class comparable, it is therefore sufficient to
 define the predicates which test equality and inferiority, and mix in


### PR DESCRIPTION
Saying that Scala's `Any` is more general than Java's `Object` is not right as both are supertypes of every class. In Java not every data type is an object, there are also primitives, such as `int`, `long` and so on, but their existence does not make `Object` less general. Every primitive has a wrapper (`Integer`, `Long`, ...) extending in some way `Object` (through `Number`).